### PR TITLE
fix: [del-5514]: uncomment default provider

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,7 +1,7 @@
-// provider "helm" {
-//
-//   kubernetes {
-//     config_path = "~/.kube/config"
-//   }
-//
-// }
+provider "helm" {
+
+  kubernetes {
+    config_path = "~/.kube/config"
+  }
+
+}


### PR DESCRIPTION
Uncomment default provider in the module
The default one will allow deployment to the default k8s cluster in local .kube/config file